### PR TITLE
Convert links to https

### DIFF
--- a/docs/osmose.html
+++ b/docs/osmose.html
@@ -60,11 +60,11 @@
 <script type="text/javascript">
   var attributions = [
     'Map data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors',
-    'POI via <a href="http://wiki.openstreetmap.org/wiki/Osmose">Osmose API</a>',
+    'POI via <a href="https://wiki.openstreetmap.org/wiki/Osmose">Osmose API</a>',
   ];
 
   var tileLayer = new L.TileLayer(
-    'http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png',
+    'https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png',
     { attribution: attributions.join(', ') }
   );
 


### PR DESCRIPTION
Removes mixed content warning. The ssl certificate on tiles.wmflabs.org doesn't have the sub-subdomains, but tiles.wmflabs.org supports HTTP/2.0, so there's no performance loss.